### PR TITLE
Note support for pipelining

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,16 +282,16 @@ Java     -  ??
 (Note: Reel supports Rack via reel-rack addon)
 
 
-| Server     | Multi-Threaded | Multi-Fiber | Multi-Process | Evented | Watchdog | C Extension |
-| :--------  | :------------: | :---------: | :-----------: | :-----: | :------: | :---------: |
-| WEBRick    |  Yes           |   x         |    x          |   x     |   x      |   x         |
-| Passenger  |  Yes           |   x         |   Yes         |  Yes    |  Yes     |  Yes        |
-| Puma       |  Yes           |   x         |   Yes         |   x     |   x      |  Yes        |
-| Unicorn    |   x            |   x         |   Yes         |  Yes    |  Yes     |  Yes        | 
-| Thin       |  Yes           |   x         |    x          |  Yes    |   x      |  Yes        |
-| Goliath    |   x            |  Yes        |    x          |  Yes    |   x      |  Yes        |
-| Reel       |   x            |  Yes (*)    |    x          |  Yes    |   x      |  Yes        |
-| HTTP-2     |  ??            |   x         |    x          |  Yes    |   x      |   x         |
+| Server     | Multi-Threaded | Multi-Fiber | Multi-Process | Evented | Watchdog | C Extension | Pipelining |
+| :--------  | :------------: | :---------: | :-----------: | :-----: | :------: | :---------: | :--------: |
+| WEBRick    |  Yes           |   x         |    x          |   x     |   x      |   x         |   x        |
+| Passenger  |  Yes           |   x         |   Yes         |  Yes    |  Yes     |  Yes        |   x        |
+| Puma       |  Yes           |   x         |   Yes         |   x     |   x      |  Yes        |   x        |
+| Unicorn    |   x            |   x         |   Yes         |  Yes    |  Yes     |  Yes        |   x        |
+| Thin       |  Yes           |   x         |    x          |  Yes    |   x      |  Yes        |   x        |
+| Goliath    |   x            |  Yes        |    x          |  Yes    |   x      |  Yes        |  Yes       |
+| Reel       |   x            |  Yes (*)    |    x          |  Yes    |   x      |  Yes        |  Yes       |
+| HTTP-2     |  ??            |   x         |    x          |  Yes    |   x      |   x         |  Yes       |
 
 
 (Note: Thin, Goliath, ... using EventMachine - ;


### PR DESCRIPTION
I think support for [HTTP pipelining](https://en.wikipedia.org/wiki/HTTP_pipelining) is an interesting thing to capture.

I tried to research this and note which web servers support it.

I couldn't find any information on WEBRick or Passenger. Just a quick look over the code on WEBRick didn't turn up anything.

For Puma I found this closed issue, which leads me to believe it doesn't: https://github.com/puma/puma/issues/2

Unicorn explicitly documents that it does not support pipelining.

For Thin there's an open issue where several people repeatedly claim pipelining is broken: https://github.com/macournoyer/thin/issues/40

Pipelining is an [explicit design goal of Goliath](https://www.igvita.com/2011/10/04/optimizing-http-keep-alive-and-pipelining/), and HTTP-2 supports a more advanced model (perhaps HTTP-2 should get an asterisk to note that it's message-oriented and therefore even more advanced than traditional pipelining)

Reel has pipelining support. Source: I'm the author :wink:
