### PR TITLE
Use a simpler command line version to request WEBrick help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ $ ruby -run -e httpd ./_site -p 5000
 or to get all options:
 
 ~~~
-$ ruby -e "require 'un'; httpd" -- --help
+$ ruby -run -e httpd -- --help
 ~~~
 
 resulting in:


### PR DESCRIPTION
The same simpler version is used above, so make sense to keep using the same.
